### PR TITLE
Move angle bracket syntax explanation to reference/syntax-conversion-guide

### DIFF
--- a/guides/v3.7.0/pages.yml
+++ b/guides/v3.7.0/pages.yml
@@ -98,8 +98,6 @@
   pages:
     - title: "Templating Basics"
       url: "handlebars-basics"
-    - title: "Angle Bracket Syntax"
-      url: "angle-bracket-syntax"
     - title: "Built-in Helpers"
       url: "built-in-helpers"
     - title: "Conditionals"
@@ -290,3 +288,9 @@
   pages:
     - title: "Web Development"
       url: "web-development"
+
+- title: 'Reference'
+  url: 'reference'
+  pages:
+    - title: "Syntax Conversion Guide"
+      url: "syntax-conversion-guide"

--- a/guides/v3.7.0/reference/syntax-conversion-guide.md
+++ b/guides/v3.7.0/reference/syntax-conversion-guide.md
@@ -1,3 +1,5 @@
+## Angle Bracket Syntax
+
 The [Angle Bracket Syntax](https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md) is an alternative style of invoking components in templates. The difference between the Angle Bracket Syntax and the Classic Invocation Syntax is purely syntactical and does not affect the semantics of invoking a component.
 
 **Classical Invocation Syntax:**


### PR DESCRIPTION
From: https://github.com/ember-learn/guides-source/pull/357
Moving the explanation to `reference/syntax-conversion-guide` and added a title since the page title is now "Syntax Conversion Guide"

cc @jenweber and @cah-danmonroe 